### PR TITLE
Add missing curly brace to media query

### DIFF
--- a/templates/convio/Letters/Email_Letter_Colorful.html
+++ b/templates/convio/Letters/Email_Letter_Colorful.html
@@ -261,64 +261,57 @@
                 #bodyCell{padding:10px !important;}
             }
             
-            @media screen and (max-width:550px) { 
-                
-                .image-column img {
-                    width: 100% !important;
-                }
-                
-                
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-            
-                .action-button img {
-                    Margin: 0 auto !important;
-                }
-                
-                .action-button td {
-                    padding: 0 20px 20px 20px !important;
-                }
-            @media screen and (max-width:480px) {
-      
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-                .unit-name {
-                    text-align: center !important;
-                }
-                 .subhead {
-                    font-size: 15px !important;
-                }
-                .body-copy, p {
-                    font-size: 14px !important;
-                    line-height: 160% !important;
-                    text-align: left !important;
-                    
-                }
-                
-                .grey-bar-footer a {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                }
-                
-                .contact-footer {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                    padding: 4px 0 !important;
-                    
-                }
-            
+            @media screen and (max-width:550px) {
+              .image-column img {
+                width: 100% !important;
+              }
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .action-button img {
+                Margin: 0 auto !important;
+              }
+              .action-button td {
+                padding: 0 20px 20px 20px !important;
+              }
             }
+            
+            @media screen and (max-width:480px) {
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .unit-name {
+                text-align: center !important;
+              }
+              .subhead {
+                font-size: 15px !important;
+              }
+              .body-copy,
+              p {
+                font-size: 14px !important;
+                line-height: 160% !important;
+                text-align: left !important;
+              }
+              .grey-bar-footer a {
+                font-size: 13px !important;
+                line-height: 2 !important;
+              }
+              .contact-footer {
+                font-size: 13px !important;
+                line-height: 2 !important;
+                padding: 4px 0 !important;
+              }
+            }
+            
             @media screen and (max-width:395px) {
-                .anti-spam-links {
-                    padding: 16px 35px 8px 35px !important;
-                }
-                .anti-spam-links a {
-                    padding: 0 8px  !important;
-                }  
+              .anti-spam-links {
+                padding: 16px 35px 8px 35px !important;
+              }
+              .anti-spam-links a {
+                padding: 0 8px !important;
+              }
             }
             
         </style>

--- a/templates/convio/Letters/Email_Letter_Head_Small_Image.html
+++ b/templates/convio/Letters/Email_Letter_Head_Small_Image.html
@@ -261,64 +261,57 @@
                 #bodyCell{padding:10px !important;}
             }
             
-            @media screen and (max-width:550px) { 
-                
-                .image-column img {
-                    width: 100% !important;
-                }
-                
-                
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-            
-                .action-button img {
-                    Margin: 0 auto !important;
-                }
-                
-                .action-button td {
-                    padding: 0 20px 20px 20px !important;
-                }
-            @media screen and (max-width:480px) {
-      
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-                .unit-name {
-                    text-align: center !important;
-                }
-                 .subhead {
-                    font-size: 15px !important;
-                }
-                .body-copy, p {
-                    font-size: 14px !important;
-                    line-height: 160% !important;
-                    text-align: left !important;
-                    
-                }
-                
-                .grey-bar-footer a {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                }
-                
-                .contact-footer {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                    padding: 4px 0 !important;
-                    
-                }
-            
+            @media screen and (max-width:550px) {
+              .image-column img {
+                width: 100% !important;
+              }
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .action-button img {
+                Margin: 0 auto !important;
+              }
+              .action-button td {
+                padding: 0 20px 20px 20px !important;
+              }
             }
+            
+            @media screen and (max-width:480px) {
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .unit-name {
+                text-align: center !important;
+              }
+              .subhead {
+                font-size: 15px !important;
+              }
+              .body-copy,
+              p {
+                font-size: 14px !important;
+                line-height: 160% !important;
+                text-align: left !important;
+              }
+              .grey-bar-footer a {
+                font-size: 13px !important;
+                line-height: 2 !important;
+              }
+              .contact-footer {
+                font-size: 13px !important;
+                line-height: 2 !important;
+                padding: 4px 0 !important;
+              }
+            }
+            
             @media screen and (max-width:395px) {
-                .anti-spam-links {
-                    padding: 16px 35px 8px 35px !important;
-                }
-                .anti-spam-links a {
-                    padding: 0 8px  !important;
-                }  
+              .anti-spam-links {
+                padding: 16px 35px 8px 35px !important;
+              }
+              .anti-spam-links a {
+                padding: 0 8px !important;
+              }
             }
             
         </style>

--- a/templates/convio/Letters/Email_Letter_Headline.html
+++ b/templates/convio/Letters/Email_Letter_Headline.html
@@ -261,64 +261,57 @@
                 #bodyCell{padding:10px !important;}
             }
             
-            @media screen and (max-width:550px) { 
-                
-                .image-column img {
-                    width: 100% !important;
-                }
-                
-                
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-            
-                .action-button img {
-                    Margin: 0 auto !important;
-                }
-                
-                .action-button td {
-                    padding: 0 20px 20px 20px !important;
-                }
-            @media screen and (max-width:480px) {
-      
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-                .unit-name {
-                    text-align: center !important;
-                }
-                 .subhead {
-                    font-size: 15px !important;
-                }
-                .body-copy, p {
-                    font-size: 14px !important;
-                    line-height: 160% !important;
-                    text-align: left !important;
-                    
-                }
-                
-                .grey-bar-footer a {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                }
-                
-                .contact-footer {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                    padding: 4px 0 !important;
-                    
-                }
-            
+            @media screen and (max-width:550px) {
+              .image-column img {
+                width: 100% !important;
+              }
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .action-button img {
+                Margin: 0 auto !important;
+              }
+              .action-button td {
+                padding: 0 20px 20px 20px !important;
+              }
             }
+            
+            @media screen and (max-width:480px) {
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .unit-name {
+                text-align: center !important;
+              }
+              .subhead {
+                font-size: 15px !important;
+              }
+              .body-copy,
+              p {
+                font-size: 14px !important;
+                line-height: 160% !important;
+                text-align: left !important;
+              }
+              .grey-bar-footer a {
+                font-size: 13px !important;
+                line-height: 2 !important;
+              }
+              .contact-footer {
+                font-size: 13px !important;
+                line-height: 2 !important;
+                padding: 4px 0 !important;
+              }
+            }
+            
             @media screen and (max-width:395px) {
-                .anti-spam-links {
-                    padding: 16px 35px 8px 35px !important;
-                }
-                .anti-spam-links a {
-                    padding: 0 8px  !important;
-                }  
+              .anti-spam-links {
+                padding: 16px 35px 8px 35px !important;
+              }
+              .anti-spam-links a {
+                padding: 0 8px !important;
+              }
             }
             
         </style>

--- a/templates/convio/Letters/Email_Letter_ImageHead.html
+++ b/templates/convio/Letters/Email_Letter_ImageHead.html
@@ -261,64 +261,57 @@
                 #bodyCell{padding:10px !important;}
             }
             
-            @media screen and (max-width:550px) { 
-                
-                .image-column img {
-                    width: 100% !important;
-                }
-                
-                
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-            
-                .action-button img {
-                    Margin: 0 auto !important;
-                }
-                
-                .action-button td {
-                    padding: 0 20px 20px 20px !important;
-                }
-            @media screen and (max-width:480px) {
-      
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-                .unit-name {
-                    text-align: center !important;
-                }
-                 .subhead {
-                    font-size: 15px !important;
-                }
-                .body-copy, p {
-                    font-size: 14px !important;
-                    line-height: 160% !important;
-                    text-align: left !important;
-                    
-                }
-                
-                .grey-bar-footer a {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                }
-                
-                .contact-footer {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                    padding: 4px 0 !important;
-                    
-                }
-            
+            @media screen and (max-width:550px) {
+              .image-column img {
+                width: 100% !important;
+              }
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .action-button img {
+                Margin: 0 auto !important;
+              }
+              .action-button td {
+                padding: 0 20px 20px 20px !important;
+              }
             }
+            
+            @media screen and (max-width:480px) {
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .unit-name {
+                text-align: center !important;
+              }
+              .subhead {
+                font-size: 15px !important;
+              }
+              .body-copy,
+              p {
+                font-size: 14px !important;
+                line-height: 160% !important;
+                text-align: left !important;
+              }
+              .grey-bar-footer a {
+                font-size: 13px !important;
+                line-height: 2 !important;
+              }
+              .contact-footer {
+                font-size: 13px !important;
+                line-height: 2 !important;
+                padding: 4px 0 !important;
+              }
+            }
+            
             @media screen and (max-width:395px) {
-                .anti-spam-links {
-                    padding: 16px 35px 8px 35px !important;
-                }
-                .anti-spam-links a {
-                    padding: 0 8px  !important;
-                }  
+              .anti-spam-links {
+                padding: 16px 35px 8px 35px !important;
+              }
+              .anti-spam-links a {
+                padding: 0 8px !important;
+              }
             }
             
         </style>

--- a/templates/convio/Letters/Email_Letter_ImageHead_PurpleSubheads.html
+++ b/templates/convio/Letters/Email_Letter_ImageHead_PurpleSubheads.html
@@ -261,64 +261,57 @@
                 #bodyCell{padding:10px !important;}
             }
             
-            @media screen and (max-width:550px) { 
-                
-                .image-column img {
-                    width: 100% !important;
-                }
-                
-                
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-            
-                .action-button img {
-                    Margin: 0 auto !important;
-                }
-                
-                .action-button td {
-                    padding: 0 20px 20px 20px !important;
-                }
-            @media screen and (max-width:480px) {
-      
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-                .unit-name {
-                    text-align: center !important;
-                }
-                 .subhead {
-                    font-size: 15px !important;
-                }
-                .body-copy, p {
-                    font-size: 14px !important;
-                    line-height: 160% !important;
-                    text-align: left !important;
-                    
-                }
-                
-                .grey-bar-footer a {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                }
-                
-                .contact-footer {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                    padding: 4px 0 !important;
-                    
-                }
-            
+            @media screen and (max-width:550px) {
+              .image-column img {
+                width: 100% !important;
+              }
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .action-button img {
+                Margin: 0 auto !important;
+              }
+              .action-button td {
+                padding: 0 20px 20px 20px !important;
+              }
             }
+            
+            @media screen and (max-width:480px) {
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .unit-name {
+                text-align: center !important;
+              }
+              .subhead {
+                font-size: 15px !important;
+              }
+              .body-copy,
+              p {
+                font-size: 14px !important;
+                line-height: 160% !important;
+                text-align: left !important;
+              }
+              .grey-bar-footer a {
+                font-size: 13px !important;
+                line-height: 2 !important;
+              }
+              .contact-footer {
+                font-size: 13px !important;
+                line-height: 2 !important;
+                padding: 4px 0 !important;
+              }
+            }
+            
             @media screen and (max-width:395px) {
-                .anti-spam-links {
-                    padding: 16px 35px 8px 35px !important;
-                }
-                .anti-spam-links a {
-                    padding: 0 8px  !important;
-                }  
+              .anti-spam-links {
+                padding: 16px 35px 8px 35px !important;
+              }
+              .anti-spam-links a {
+                padding: 0 8px !important;
+              }
             }
             
         </style>

--- a/templates/convio/Letters/Email_Letter_Simple.html
+++ b/templates/convio/Letters/Email_Letter_Simple.html
@@ -261,64 +261,57 @@
                 #bodyCell{padding:10px !important;}
             }
             
-            @media screen and (max-width:550px) { 
-                
-                .image-column img {
-                    width: 100% !important;
-                }
-                
-                
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-            
-                .action-button img {
-                    Margin: 0 auto !important;
-                }
-                
-                .action-button td {
-                    padding: 0 20px 20px 20px !important;
-                }
-            @media screen and (max-width:480px) {
-      
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-                .unit-name {
-                    text-align: center !important;
-                }
-                 .subhead {
-                    font-size: 15px !important;
-                }
-                .body-copy, p {
-                    font-size: 14px !important;
-                    line-height: 160% !important;
-                    text-align: left !important;
-                    
-                }
-                
-                .grey-bar-footer a {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                }
-                
-                .contact-footer {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                    padding: 4px 0 !important;
-                    
-                }
-            
+            @media screen and (max-width:550px) {
+              .image-column img {
+                width: 100% !important;
+              }
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .action-button img {
+                Margin: 0 auto !important;
+              }
+              .action-button td {
+                padding: 0 20px 20px 20px !important;
+              }
             }
+            
+            @media screen and (max-width:480px) {
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .unit-name {
+                text-align: center !important;
+              }
+              .subhead {
+                font-size: 15px !important;
+              }
+              .body-copy,
+              p {
+                font-size: 14px !important;
+                line-height: 160% !important;
+                text-align: left !important;
+              }
+              .grey-bar-footer a {
+                font-size: 13px !important;
+                line-height: 2 !important;
+              }
+              .contact-footer {
+                font-size: 13px !important;
+                line-height: 2 !important;
+                padding: 4px 0 !important;
+              }
+            }
+            
             @media screen and (max-width:395px) {
-                .anti-spam-links {
-                    padding: 16px 35px 8px 35px !important;
-                }
-                .anti-spam-links a {
-                    padding: 0 8px  !important;
-                }  
+              .anti-spam-links {
+                padding: 16px 35px 8px 35px !important;
+              }
+              .anti-spam-links a {
+                padding: 0 8px !important;
+              }
             }
             
         </style>

--- a/templates/convio/SingleEvent/Email_SingleEvent_1Col_Colorful.html
+++ b/templates/convio/SingleEvent/Email_SingleEvent_1Col_Colorful.html
@@ -261,27 +261,23 @@
                 #bodyCell{padding:10px !important;}
             }
             
-            @media screen and (max-width:550px) { 
-                
+            @media screen and (max-width:550px) {
                 .image-column img {
                     width: 100% !important;
                 }
-                
-                
                 .stack-column {
                     display: block !important;
                     width: 100% !important;
                 }
-            
                 .action-button img {
                     Margin: 0 auto !important;
                 }
-                
                 .action-button td {
                     padding: 0 20px 20px 20px !important;
                 }
+            }
+            
             @media screen and (max-width:480px) {
-      
                 .stack-column {
                     display: block !important;
                     width: 100% !important;
@@ -289,7 +285,7 @@
                 .unit-name {
                     text-align: center !important;
                 }
-                 .subhead {
+                .subhead {
                     font-size: 15px !important;
                 }
                 .body-copy, p {
@@ -298,27 +294,25 @@
                     text-align: left !important;
                     
                 }
-                
                 .grey-bar-footer a {
                     font-size: 13px !important;
                     line-height: 2 !important;
                 }
-                
                 .contact-footer {
                     font-size: 13px !important;
                     line-height: 2 !important;
                     padding: 4px 0 !important;
                     
                 }
-            
             }
+            
             @media screen and (max-width:395px) {
                 .anti-spam-links {
                     padding: 16px 35px 8px 35px !important;
                 }
                 .anti-spam-links a {
                     padding: 0 8px  !important;
-                }  
+                }
             }
             
         </style>

--- a/templates/convio/SingleEvent/Email_SingleEvent_1Col_Simple.html
+++ b/templates/convio/SingleEvent/Email_SingleEvent_1Col_Simple.html
@@ -261,64 +261,57 @@
                 #bodyCell{padding:10px !important;}
             }
             
-            @media screen and (max-width:550px) { 
-                
-                .image-column img {
-                    width: 100% !important;
-                }
-                
-                
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-            
-                .action-button img {
-                    Margin: 0 auto !important;
-                }
-                
-                .action-button td {
-                    padding: 0 20px 20px 20px !important;
-                }
-            @media screen and (max-width:480px) {
-      
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-                .unit-name {
-                    text-align: center !important;
-                }
-                 .subhead {
-                    font-size: 15px !important;
-                }
-                .body-copy, p {
-                    font-size: 14px !important;
-                    line-height: 160% !important;
-                    text-align: left !important;
-                    
-                }
-                
-                .grey-bar-footer a {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                }
-                
-                .contact-footer {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                    padding: 4px 0 !important;
-                    
-                }
-            
+            @media screen and (max-width:550px) {
+              .image-column img {
+                width: 100% !important;
+              }
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .action-button img {
+                Margin: 0 auto !important;
+              }
+              .action-button td {
+                padding: 0 20px 20px 20px !important;
+              }
             }
+            
+            @media screen and (max-width:480px) {
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .unit-name {
+                text-align: center !important;
+              }
+              .subhead {
+                font-size: 15px !important;
+              }
+              .body-copy,
+              p {
+                font-size: 14px !important;
+                line-height: 160% !important;
+                text-align: left !important;
+              }
+              .grey-bar-footer a {
+                font-size: 13px !important;
+                line-height: 2 !important;
+              }
+              .contact-footer {
+                font-size: 13px !important;
+                line-height: 2 !important;
+                padding: 4px 0 !important;
+              }
+            }
+            
             @media screen and (max-width:395px) {
-                .anti-spam-links {
-                    padding: 16px 35px 8px 35px !important;
-                }
-                .anti-spam-links a {
-                    padding: 0 8px  !important;
-                }  
+              .anti-spam-links {
+                padding: 16px 35px 8px 35px !important;
+              }
+              .anti-spam-links a {
+                padding: 0 8px !important;
+              }
             }
             
         </style>

--- a/templates/convio/SingleEvent/Email_SingleEvent_1Col_Subhead.html
+++ b/templates/convio/SingleEvent/Email_SingleEvent_1Col_Subhead.html
@@ -261,64 +261,57 @@
                 #bodyCell{padding:10px !important;}
             }
             
-            @media screen and (max-width:550px) { 
-                
-                .image-column img {
-                    width: 100% !important;
-                }
-                
-                
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-            
-                .action-button img {
-                    Margin: 0 auto !important;
-                }
-                
-                .action-button td {
-                    padding: 0 20px 20px 20px !important;
-                }
-            @media screen and (max-width:480px) {
-      
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-                .unit-name {
-                    text-align: center !important;
-                }
-                 .subhead {
-                    font-size: 15px !important;
-                }
-                .body-copy, p {
-                    font-size: 14px !important;
-                    line-height: 160% !important;
-                    text-align: left !important;
-                    
-                }
-                
-                .grey-bar-footer a {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                }
-                
-                .contact-footer {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                    padding: 4px 0 !important;
-                    
-                }
-            
+            @media screen and (max-width:550px) {
+              .image-column img {
+                width: 100% !important;
+              }
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .action-button img {
+                Margin: 0 auto !important;
+              }
+              .action-button td {
+                padding: 0 20px 20px 20px !important;
+              }
             }
+            
+            @media screen and (max-width:480px) {
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .unit-name {
+                text-align: center !important;
+              }
+              .subhead {
+                font-size: 15px !important;
+              }
+              .body-copy,
+              p {
+                font-size: 14px !important;
+                line-height: 160% !important;
+                text-align: left !important;
+              }
+              .grey-bar-footer a {
+                font-size: 13px !important;
+                line-height: 2 !important;
+              }
+              .contact-footer {
+                font-size: 13px !important;
+                line-height: 2 !important;
+                padding: 4px 0 !important;
+              }
+            }
+            
             @media screen and (max-width:395px) {
-                .anti-spam-links {
-                    padding: 16px 35px 8px 35px !important;
-                }
-                .anti-spam-links a {
-                    padding: 0 8px  !important;
-                }  
+              .anti-spam-links {
+                padding: 16px 35px 8px 35px !important;
+              }
+              .anti-spam-links a {
+                padding: 0 8px !important;
+              }
             }
             
         </style>

--- a/templates/convio/SingleEvent/Email_SingleEvent_2Col_Colorful.html
+++ b/templates/convio/SingleEvent/Email_SingleEvent_2Col_Colorful.html
@@ -261,64 +261,57 @@
                 #bodyCell{padding:10px !important;}
             }
             
-            @media screen and (max-width:550px) { 
-                
-                .image-column img {
-                    width: 100% !important;
-                }
-                
-                
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-            
-                .action-button img {
-                    Margin: 0 auto !important;
-                }
-                
-                .action-button td {
-                    padding: 0 20px 20px 20px !important;
-                }
-            @media screen and (max-width:480px) {
-      
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-                .unit-name {
-                    text-align: center !important;
-                }
-                 .subhead {
-                    font-size: 15px !important;
-                }
-                .body-copy, p {
-                    font-size: 14px !important;
-                    line-height: 160% !important;
-                    text-align: left !important;
-                    
-                }
-                
-                .grey-bar-footer a {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                }
-                
-                .contact-footer {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                    padding: 4px 0 !important;
-                    
-                }
-            
+            @media screen and (max-width:550px) {
+              .image-column img {
+                width: 100% !important;
+              }
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .action-button img {
+                Margin: 0 auto !important;
+              }
+              .action-button td {
+                padding: 0 20px 20px 20px !important;
+              }
             }
+            
+            @media screen and (max-width:480px) {
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .unit-name {
+                text-align: center !important;
+              }
+              .subhead {
+                font-size: 15px !important;
+              }
+              .body-copy,
+              p {
+                font-size: 14px !important;
+                line-height: 160% !important;
+                text-align: left !important;
+              }
+              .grey-bar-footer a {
+                font-size: 13px !important;
+                line-height: 2 !important;
+              }
+              .contact-footer {
+                font-size: 13px !important;
+                line-height: 2 !important;
+                padding: 4px 0 !important;
+              }
+            }
+            
             @media screen and (max-width:395px) {
-                .anti-spam-links {
-                    padding: 16px 35px 8px 35px !important;
-                }
-                .anti-spam-links a {
-                    padding: 0 8px  !important;
-                }  
+              .anti-spam-links {
+                padding: 16px 35px 8px 35px !important;
+              }
+              .anti-spam-links a {
+                padding: 0 8px !important;
+              }
             }
             
         </style>

--- a/templates/convio/SingleEvent/Email_SingleEvent_2Col_Simple.html
+++ b/templates/convio/SingleEvent/Email_SingleEvent_2Col_Simple.html
@@ -261,64 +261,57 @@
                 #bodyCell{padding:10px !important;}
             }
             
-            @media screen and (max-width:550px) { 
-                
-                .image-column img {
-                    width: 100% !important;
-                }
-                
-                
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-            
-                .action-button img {
-                    Margin: 0 auto !important;
-                }
-                
-                .action-button td {
-                    padding: 0 20px 20px 20px !important;
-                }
-            @media screen and (max-width:480px) {
-      
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-                .unit-name {
-                    text-align: center !important;
-                }
-                 .subhead {
-                    font-size: 15px !important;
-                }
-                .body-copy, p {
-                    font-size: 14px !important;
-                    line-height: 160% !important;
-                    text-align: left !important;
-                    
-                }
-                
-                .grey-bar-footer a {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                }
-                
-                .contact-footer {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                    padding: 4px 0 !important;
-                    
-                }
-            
+            @media screen and (max-width:550px) {
+              .image-column img {
+                width: 100% !important;
+              }
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .action-button img {
+                Margin: 0 auto !important;
+              }
+              .action-button td {
+                padding: 0 20px 20px 20px !important;
+              }
             }
+            
+            @media screen and (max-width:480px) {
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .unit-name {
+                text-align: center !important;
+              }
+              .subhead {
+                font-size: 15px !important;
+              }
+              .body-copy,
+              p {
+                font-size: 14px !important;
+                line-height: 160% !important;
+                text-align: left !important;
+              }
+              .grey-bar-footer a {
+                font-size: 13px !important;
+                line-height: 2 !important;
+              }
+              .contact-footer {
+                font-size: 13px !important;
+                line-height: 2 !important;
+                padding: 4px 0 !important;
+              }
+            }
+            
             @media screen and (max-width:395px) {
-                .anti-spam-links {
-                    padding: 16px 35px 8px 35px !important;
-                }
-                .anti-spam-links a {
-                    padding: 0 8px  !important;
-                }  
+              .anti-spam-links {
+                padding: 16px 35px 8px 35px !important;
+              }
+              .anti-spam-links a {
+                padding: 0 8px !important;
+              }
             }
             
         </style>

--- a/templates/convio/SingleEvent/Email_SingleEvent_2Col_Subhead.html
+++ b/templates/convio/SingleEvent/Email_SingleEvent_2Col_Subhead.html
@@ -261,64 +261,57 @@
                 #bodyCell{padding:10px !important;}
             }
             
-            @media screen and (max-width:550px) { 
-                
-                .image-column img {
-                    width: 100% !important;
-                }
-                
-                
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-            
-                .action-button img {
-                    Margin: 0 auto !important;
-                }
-                
-                .action-button td {
-                    padding: 0 20px 20px 20px !important;
-                }
-            @media screen and (max-width:480px) {
-      
-                .stack-column {
-                    display: block !important;
-                    width: 100% !important;
-                }
-                .unit-name {
-                    text-align: center !important;
-                }
-                 .subhead {
-                    font-size: 15px !important;
-                }
-                .body-copy, p {
-                    font-size: 14px !important;
-                    line-height: 160% !important;
-                    text-align: left !important;
-                    
-                }
-                
-                .grey-bar-footer a {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                }
-                
-                .contact-footer {
-                    font-size: 13px !important;
-                    line-height: 2 !important;
-                    padding: 4px 0 !important;
-                    
-                }
-            
+            @media screen and (max-width:550px) {
+              .image-column img {
+                width: 100% !important;
+              }
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .action-button img {
+                Margin: 0 auto !important;
+              }
+              .action-button td {
+                padding: 0 20px 20px 20px !important;
+              }
             }
+            
+            @media screen and (max-width:480px) {
+              .stack-column {
+                display: block !important;
+                width: 100% !important;
+              }
+              .unit-name {
+                text-align: center !important;
+              }
+              .subhead {
+                font-size: 15px !important;
+              }
+              .body-copy,
+              p {
+                font-size: 14px !important;
+                line-height: 160% !important;
+                text-align: left !important;
+              }
+              .grey-bar-footer a {
+                font-size: 13px !important;
+                line-height: 2 !important;
+              }
+              .contact-footer {
+                font-size: 13px !important;
+                line-height: 2 !important;
+                padding: 4px 0 !important;
+              }
+            }
+            
             @media screen and (max-width:395px) {
-                .anti-spam-links {
-                    padding: 16px 35px 8px 35px !important;
-                }
-                .anti-spam-links a {
-                    padding: 0 8px  !important;
-                }  
+              .anti-spam-links {
+                padding: 16px 35px 8px 35px !important;
+              }
+              .anti-spam-links a {
+                padding: 0 8px !important;
+              }
             }
             
         </style>


### PR DESCRIPTION
The first media query (at line 264) was missing its closing brace in all templates but those in the Newsletters folder. I also cleaned up some white space just within these lines.
