### PR TITLE
Add missing dash to a closing comment tag

### DIFF
--- a/templates/convio/Letters/Email_Letter_Colorful.html
+++ b/templates/convio/Letters/Email_Letter_Colorful.html
@@ -468,7 +468,7 @@ THE NEXT MANNEQUIN SNIPPET - TABLE - CAN GO BELOW
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-->           
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->
+            All Mannequin Snippets go above this comment-->
                 
                   <!--FOOTER GRAY BAR WRAPPER-->
                 <table border="0" cellspacing="0" cellpadding="0" width="100%" class="cool-grey-background grey-bar-footer">

--- a/templates/convio/Letters/Email_Letter_Head_Small_Image.html
+++ b/templates/convio/Letters/Email_Letter_Head_Small_Image.html
@@ -457,7 +457,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-->
                 
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->
+            All Mannequin Snippets go above this comment-->
                 
                   <!--FOOTER GRAY BAR WRAPPER-->
                 <table border="0" cellspacing="0" cellpadding="0" width="100%" class="cool-grey-background grey-bar-footer">

--- a/templates/convio/Letters/Email_Letter_Headline.html
+++ b/templates/convio/Letters/Email_Letter_Headline.html
@@ -450,7 +450,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-->
                 
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->
+            All Mannequin Snippets go above this comment-->
                 
                   <!--FOOTER GRAY BAR WRAPPER-->
                 <table border="0" cellspacing="0" cellpadding="0" width="100%" class="cool-grey-background grey-bar-footer">

--- a/templates/convio/Letters/Email_Letter_ImageHead.html
+++ b/templates/convio/Letters/Email_Letter_ImageHead.html
@@ -495,7 +495,7 @@ THE NEXT MANNEQUIN SNIPPET - TABLE - CAN GO BELOW
 XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-->           
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->
+            All Mannequin Snippets go above this comment-->
                 
                   <!--FOOTER GRAY BAR WRAPPER-->
                 <table border="0" cellspacing="0" cellpadding="0" width="100%" class="cool-grey-background grey-bar-footer">

--- a/templates/convio/Letters/Email_Letter_ImageHead_PurpleSubheads.html
+++ b/templates/convio/Letters/Email_Letter_ImageHead_PurpleSubheads.html
@@ -507,7 +507,7 @@ NEXT MANNEQUIN SNIPPET - TABLE - GOES BELOW
 OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO-->
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->
+            All Mannequin Snippets go above this comment-->
                 
                   <!--FOOTER GRAY BAR WRAPPER-->
                 <table border="0" cellspacing="0" cellpadding="0" width="100%" class="cool-grey-background grey-bar-footer">

--- a/templates/convio/Letters/Email_Letter_Simple.html
+++ b/templates/convio/Letters/Email_Letter_Simple.html
@@ -446,7 +446,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-->
                 
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->
+            All Mannequin Snippets go above this comment-->
                 
                   <!--FOOTER GRAY BAR WRAPPER-->
                 <table border="0" cellspacing="0" cellpadding="0" width="100%" class="cool-grey-background grey-bar-footer">

--- a/templates/convio/Newsletters/Email_Newsletter_2Col_3Col.html
+++ b/templates/convio/Newsletters/Email_Newsletter_2Col_3Col.html
@@ -750,7 +750,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-->
                 
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->
+            All Mannequin Snippets go above this comment-->
                 
                   <!--FOOTER GRAY BAR WRAPPER-->
                 <table border="0" cellspacing="0" cellpadding="0" width="100%" class="cool-grey-background grey-bar-footer">

--- a/templates/convio/Newsletters/Email_Newsletter_2Col_4Col.html
+++ b/templates/convio/Newsletters/Email_Newsletter_2Col_4Col.html
@@ -742,7 +742,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-->
                 
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->
+            All Mannequin Snippets go above this comment-->
                 
                   <!--FOOTER GRAY BAR WRAPPER-->
                 <table border="0" cellspacing="0" cellpadding="0" width="100%" class="cool-grey-background grey-bar-footer">

--- a/templates/convio/SingleEvent/Email_SingleEvent_1Col_Colorful.html
+++ b/templates/convio/SingleEvent/Email_SingleEvent_1Col_Colorful.html
@@ -459,7 +459,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-->
                 
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->             
+            All Mannequin Snippets go above this comment-->             
                 
             
  <!--FOOTER GRAY BAR WRAPPER-->

--- a/templates/convio/SingleEvent/Email_SingleEvent_1Col_Simple.html
+++ b/templates/convio/SingleEvent/Email_SingleEvent_1Col_Simple.html
@@ -452,7 +452,7 @@ OOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO-->
                 
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->             
+            All Mannequin Snippets go above this comment-->             
                 
             
  <!--FOOTER GRAY BAR WRAPPER-->

--- a/templates/convio/SingleEvent/Email_SingleEvent_1Col_Subhead.html
+++ b/templates/convio/SingleEvent/Email_SingleEvent_1Col_Subhead.html
@@ -456,7 +456,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-->
                 
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->             
+            All Mannequin Snippets go above this comment-->             
                 
             
  <!--FOOTER GRAY BAR WRAPPER-->

--- a/templates/convio/SingleEvent/Email_SingleEvent_2Col_Colorful.html
+++ b/templates/convio/SingleEvent/Email_SingleEvent_2Col_Colorful.html
@@ -480,7 +480,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-->
                 
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->             
+            All Mannequin Snippets go above this comment-->             
                 
             
  <!--FOOTER GRAY BAR WRAPPER-->

--- a/templates/convio/SingleEvent/Email_SingleEvent_2Col_Simple.html
+++ b/templates/convio/SingleEvent/Email_SingleEvent_2Col_Simple.html
@@ -455,7 +455,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-->
                 
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->             
+            All Mannequin Snippets go above this comment-->             
                 
             
  <!--FOOTER GRAY BAR WRAPPER-->

--- a/templates/convio/SingleEvent/Email_SingleEvent_2Col_Subhead.html
+++ b/templates/convio/SingleEvent/Email_SingleEvent_2Col_Subhead.html
@@ -467,7 +467,7 @@ XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-->
                 
         <!--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
             ||||||||||||||||||||||||||||||||||||||||||||||||
-            All Mannequin Snippets go above this comment->             
+            All Mannequin Snippets go above this comment-->             
                 
             
  <!--FOOTER GRAY BAR WRAPPER-->


### PR DESCRIPTION
It wasn't breaking anything in practice, but I noticed a closing comment tag had `->` instead of `-->`.
